### PR TITLE
A few small changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ MASTER_IP ?= $(shell cd terraform && terraform output | grep emr-master | awk '{
 KEY_NAME ?= $(shell cd terraform && terraform output | grep key-name | awk '{print $$NF}')
 KEY_PATH ?= "~/.ssh/${KEY_NAME}.pem"
 
-COG_EMR_S3_PREFIX := "s3://azavea-research-emr/cog-creator/spacenet"
-
 terraform-init:
 	cd terraform; terraform init
 


### PR DESCRIPTION
# Overview

1. Remove `COG_EMR_S3_PREFIX` from `Makefile` (docs say to specify it in `options.mk` but it was getting overwritten in `Makefile`)
1. Add a function for fetching all keys from an S3 bucket that could be useful to others

# Notes

To avoid exceptions being raised by the `create_cogs` function, I had to make this change so that `target_partition_count` always returns `number_of_images`. 

```diff
 def target_partition_count(number_of_images):
-    return min(number_of_images, NUM_PARTITIONS)
+    return max(number_of_images, NUM_PARTITIONS)
```

I wasn't sure if that change would be good to commit but I thought I'd mention it. `create_cogs` seems to want 1:1 partitions to images, in which case maybe the number of partitions should just be `len(image_uris)` and we can get rid of `target_partition_count` entirely.